### PR TITLE
Remove num derive

### DIFF
--- a/src/generator/character_types.rs
+++ b/src/generator/character_types.rs
@@ -64,7 +64,7 @@ pub(crate) fn generate(autosar_schema: &AutosarDataTypes) -> String {
                 )
             }
             CharacterDataType::UnsignedInteger => "CharacterDataSpec::UnsignedInteger".to_string(),
-            CharacterDataType::Double => "CharacterDataSpec::Double".to_string(),
+            CharacterDataType::Double => "CharacterDataSpec::Float".to_string(),
         };
         generated.push_str("    ");
         generated.push_str(&chdef);


### PR DESCRIPTION
One commit changes Double to Float in the generated code, please check why that was necessary. Maybe this crate and what is published in autosar-data-specification got out of sync in some way?